### PR TITLE
Add shebang

### DIFF
--- a/eslint/node.config.mjs
+++ b/eslint/node.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig([
     files: ['script/**/*.ts', 'src/index.ts'],
     rules: {
       'n/no-process-exit': 'off',
+      'n/hashbang': 'off',
     },
   },
 ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizunashi_mana/manage-bg-mcp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Background process management MCP server - Background job management capabilities for AI agent debugging support",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { parseArgs } from 'node:util';
 import { buildContainer } from '@/container/DIContainer.js';
 import { loadConfig } from '@/services/ConfigProvider.js';


### PR DESCRIPTION
This pull request introduces a new hashbang to the entry point, disables the corresponding ESLint rule, and bumps the package version. These changes improve the usability of the CLI and ensure the linter configuration aligns with the new code.

CLI improvements:
* Added a hashbang line (`#!/usr/bin/env node`) to the top of `src/index.ts` to allow the script to be run directly from the command line.

ESLint configuration:
* Disabled the `n/hashbang` rule in `eslint/node.config.mjs` to permit the use of hashbangs in scripts.

Package metadata:
* Updated the version in `package.json` from `0.0.2` to `0.0.3`.