### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,11 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Run tests
-        run: devenv shell npm test
-
       - name: Build package
         run: devenv shell npm run build
+
+      - name: Run tests
+        run: devenv shell npm test
 
       - name: Dry run check
         if: ${{ github.event.inputs.dry_run == 'true' }}


### PR DESCRIPTION
This pull request makes a minor adjustment to the CI workflow in `.github/workflows/release.yml`. The order of the "Run tests" and "Build package" steps has been swapped so that the package is built before tests are run.

* Changed the workflow to run the "Build package" step before the "Run tests" step in the release process, ensuring that tests are executed after the package is built.