### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mizunashi-mana/manage-bg-mcp/security/code-scanning/1](https://github.com/mizunashi-mana/manage-bg-mcp/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow, specifying the minimal required permissions. Since the workflow only checks out code, builds, and runs tests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow file (above the `jobs:` key), which will apply to all jobs unless overridden. This change should be made in `.github/workflows/test.yml`, above line 9.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
